### PR TITLE
Fix login box positioning on IE11

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,1 +1,1 @@
-.login-container{height:100vh;width:100vw;display:flex;justify-content:center}.login-box{margin-top:5rem;max-width:300px;}.login-box .btn + .btn{margin-left:1rem}@-moz-document url-prefix(){fieldset{display:table-cell}}/*# sourceMappingURL=app.css.map */
+.login-box{margin-top:5rem;max-width:300px;}.login-box .btn + .btn{margin-left:1rem}@-moz-document url-prefix(){fieldset{display:table-cell}}/*# sourceMappingURL=app.css.map */

--- a/assets/css/app.css.map
+++ b/assets/css/app.css.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["../stylus/login.styl","../stylus/app.styl"],"names":[],"mappings":"AAAA,iBACC,OAAO,MACP,MAAM,MACN,QAAQ,KACR,gBAAgB,OAGjB,WACC,WAAW,KACX,UAAU,OAEV,uBACC,YAAY,KCVd,4BACE,SAAW,QAAS","file":"app.css"}
+{"version":3,"sources":["../stylus/login.styl","../stylus/app.styl"],"names":[],"mappings":"AAAA,WACC,WAAW,KACX,UAAU,OAEV,uBACC,YAAY,KCHd,4BACE,SAAW,QAAS","file":"app.css"}

--- a/assets/stylus/login.styl
+++ b/assets/stylus/login.styl
@@ -1,10 +1,3 @@
-.login-container
-	height 100vh
-	width 100vw
-	display flex
-	justify-content center
-	//align-items center
-
 .login-box
 	margin-top 5rem
 	max-width 300px


### PR DESCRIPTION
This commit removes the flexbox style attributes on the login container, which appears to have no impact on sane browsers (since the element also has auto left/right margins), and fixes an issue where the login box was not centered correctly on IE11.

I tested this manually on Chrome (mac) and IE11 (win8). Also, I started on some Mocha/Karma/Selenium tests around this, but I don't have time to finish them up right now. Let me know if you'd like me to push what I have so far.
